### PR TITLE
Relax upper bound on `base`

### DIFF
--- a/scotty-format.cabal
+++ b/scotty-format.cabal
@@ -20,7 +20,7 @@ library
   exposed-modules:     Web.Scotty.Format.Trans
   ghc-options:         -Wall
   build-depends:
-    base >= 4.8.2 && < 4.9,
+    base >= 4.8.2 && < 4.10,
     http-media >= 0.6.4 && < 0.7,
     http-types >= 0.9.1 && < 0.10,
     scotty >= 0.11 && < 0.12,


### PR DESCRIPTION
See https://github.com/potomak/scotty-format/issues/3#issuecomment-263154932

Note: this has been already fixed up on Hackage via a meta-data edit, see
https://hackage.haskell.org/package/scotty-format-0.1.0.2/revisions/