### PR TITLE
Export `ResponseFormat`. ...

### DIFF
--- a/scotty-format.cabal
+++ b/scotty-format.cabal
@@ -1,5 +1,5 @@
 name:                scotty-format
-version:             0.1.0.2
+version:             0.1.1.0
 synopsis:            Response format helper for the Scotty web framework.
 description:
   scotty-format is a helper for the Scotty web framework that helps you defining

--- a/src/Web/Scotty/Format/Trans.hs
+++ b/src/Web/Scotty/Format/Trans.hs
@@ -5,7 +5,8 @@ module Web.Scotty.Format.Trans (
   formatHtml,
   formatText,
   formatJson,
-  format
+  format,
+  ResponseFormat,
 ) where
 
 import Control.Monad (liftM, ap)
@@ -51,9 +52,9 @@ format :: (ScottyError e, Monad m)
 format mediaType action = RF [(mediaType, action)] ()
 
 
--- Private
-
 data ResponseFormat e m a = RF [(MediaType, ActionT e m ())] a
+
+-- Private
 
 instance Monad (ResponseFormat e m) where
   return = RF []


### PR DESCRIPTION
Export the `ResponseFormat` type name so that it can be used in type
signatures. Only the type name is exported. The internals are still
opaque.